### PR TITLE
fix: add .xcode.env to enable proper node version usage

### DIFF
--- a/app/ios/.xcode.env
+++ b/app/ios/.xcode.env
@@ -1,0 +1,11 @@
+# This `.xcode.env` file is versioned and is used to source the environment
+# used when running script phases inside Xcode.
+# To customize your local environment, you can create an `.xcode.env.local`
+# file that is not versioned.
+
+# NODE_BINARY variable contains the PATH to the node executable.
+#
+# Customize the NODE_BINARY variable here.
+# For example, to use nvm with brew, add the following line
+# . "$(brew --prefix nvm)/nvm.sh" --no-use
+export NODE_BINARY=$(command -v node)


### PR DESCRIPTION
# Summary of Changes

In order to generate iOS archives for releases, the NODE path must be set for Xcode, which needs to be done via a .xcode.env file in addition to configuration of the nvm path in the bash path settings (since Xcode uses bash instead of zsh).

# Related Issues

[React Native CLI GH Issue #34768](https://github.com/facebook/react-native/issues/34768#issuecomment-1256895362)
[Setting NVM Path in Bash StackOverflow answer](https://stackoverflow.com/a/59461183)

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
