### PR TITLE
fix: go to terms before privacy screen

### DIFF
--- a/core/App/navigators/RootStack.tsx
+++ b/core/App/navigators/RootStack.tsx
@@ -64,7 +64,7 @@ const RootStack: React.FC<RootStackProps> = (props: RootStackProps) => {
     dispatch({
       type: DispatchAction.DID_COMPLETE_TUTORIAL,
     })
-    navigation.navigate(Screens.Privacy)
+    navigation.navigate(Screens.Terms)
   }
 
   const initAgent = async (predefinedSecret?: WalletSecret | null): Promise<string | undefined> => {


### PR DESCRIPTION
Signed-off-by: James Ebert <jamesebert.k@gmail.com>

# Summary of Changes

Updates onboarding flow to go from Intro screens to terms screen. This will break the tweak made to the patch file, but is ultimately the better spot for it.

# Related Issues

N/A

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all _appropriate_ boxes. But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this).
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components.
- [x] Run prettier: `npm run style-format`
- [x] Updated **documentation** for changed code and new or modified features.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

_PR template adapted from the Python attrs project._
